### PR TITLE
Changes to assetchains_walletsize.sh and added docker_run_php.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM ubuntu:16.04
+LABEL Description="Install php7.0"
+RUN apt -y -qq update && apt -y -qq install php7.0-gmp php7.0

--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # komodo_scripts
+
+## Run php scripts using docker
+
+```
+./docker_run.sh genkomodo.php
+```

--- a/assetchains_walletsize.sh
+++ b/assetchains_walletsize.sh
@@ -1,73 +1,54 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# Find out the size of KMD and other KMD assetchains
 
 RESET="\033[0m"
-BLACK="\033[30m"    
-RED="\033[31m"      
-GREEN="\033[32m"    
-YELLOW="\033[33m"   
-BLUE="\033[34m"     
-MAGENTA="\033[35m"  
-CYAN="\033[36m"     
-WHITE="\033[37m"    
+BLACK="\033[30m"
+RED="\033[31m"
+GREEN="\033[32m"
+YELLOW="\033[33m"
+BLUE="\033[34m"
+MAGENTA="\033[35m"
+CYAN="\033[36m"
+WHITE="\033[37m"
 
-function show_walletsize ()
-{
-    if [ "$1" != "KMD" ]; then
-	if [ -f ~/.komodo/$1/wallet.dat ]; then
+function show_walletsize () {
+  if [ "$1" != "KMD" ]; then
+    if [ -f ~/.komodo/$1/wallet.dat ]; then
 
-	# SIZE=$(stat ~/.komodo/$1/wallet.dat | grep -Po "Size: \d*" | cut -d" " -f2)
-	# Pattern "Size: " - is only for english locale, so, we won't use it.
+      # SIZE=$(stat ~/.komodo/$1/wallet.dat | grep -Po "Size: \d*" | cut -d" " -f2)
+      # Pattern "Size: " - is only for english locale, so, we won't use it.
 
-	SIZE=$(stat ~/.komodo/$1/wallet.dat | grep -Po "\d+" | head -1)
-	else
-	SIZE=0
-	fi
+      SIZE=$(stat ~/.komodo/$1/wallet.dat | grep -Po "\d+" | head -1)
     else
-	SIZE=$(stat ~/.komodo/wallet.dat | grep -Po "\d+" | head -1)
+      SIZE=0
     fi
-    OUTSTR=$(echo $SIZE | numfmt --to=si --suffix=B)
-    if [ "$SIZE" -gt "19922944" ]; then
-        OUTSTR=${RED}$OUTSTR${RESET}
-    else
-	OUTSTR=${GREEN}$OUTSTR${RESET}
-    fi
-    printf "[%8s] %16b\n" $1 $OUTSTR
+  else
+    SIZE=$(stat ~/.komodo/wallet.dat | grep -Po "\d+" | head -1)
+  fi
+
+  OUTSTR=$(echo $SIZE | numfmt --to=si --suffix=B)
+
+  if [ "$SIZE" -gt "19922944" ]; then
+    OUTSTR=${RED}$OUTSTR${RESET}
+  else
+    OUTSTR=${GREEN}$OUTSTR${RESET}
+  fi
+
+  printf "[%8s] %16b\n" $1 $OUTSTR
 }
 
-show_walletsize REVS
-show_walletsize SUPERNET
-show_walletsize DEX
-show_walletsize PANGEA
-show_walletsize JUMBLR
-show_walletsize BET
-show_walletsize CRYPTO
-show_walletsize HODL
-show_walletsize MSHARK
-show_walletsize BOTS
-show_walletsize MGW 
-show_walletsize COQUI
-show_walletsize WLC
-show_walletsize KV
-show_walletsize CEAL
-show_walletsize MESH 
-show_walletsize MNZ
-show_walletsize AXO
-show_walletsize ETOMIC
-show_walletsize BTCH
-#show_walletsize VOTE2018
-show_walletsize PIZZA
-show_walletsize BEER
-show_walletsize NINJA
-show_walletsize OOT
-show_walletsize BNTN
-show_walletsize CHAIN
-show_walletsize PRLPAY
-show_walletsize DSEC
-show_walletsize GLXT
-show_walletsize EQL
-show_walletsize ZILLA
-show_walletsize VRSC
-show_walletsize RFOX
-show_walletsize SEC
-show_walletsize CCL
+ignore_list=(
+VOTE2018
+PIZZA
+BEER
+)
+
 show_walletsize KMD
+
+# Only assetchains
+${HOME}/komodo/src/listassetchains | while read list; do
+  if [[ "${ignore_list[@]}" =~ "${list}" ]]; then
+    continue
+  fi
+  show_walletsize $list
+done

--- a/docker_run.sh
+++ b/docker_run.sh
@@ -1,0 +1,4 @@
+
+docker run -v $(pwd):/app -it --entrypoint /bin/bash ubuntu:16.04
+
+#apt-get -y install php7.0-gmp php7.0

--- a/docker_run.sh
+++ b/docker_run.sh
@@ -1,3 +1,0 @@
-
-docker build -t ubuntu1604:php7 .
-docker run -v $(pwd):/app -it --entrypoint /bin/bash ubuntu1604:php7

--- a/docker_run.sh
+++ b/docker_run.sh
@@ -1,4 +1,3 @@
 
-docker run -v $(pwd):/app -it --entrypoint /bin/bash ubuntu:16.04
-
-#apt-get -y install php7.0-gmp php7.0
+docker build -t ubuntu1604:php7 .
+docker run -v $(pwd):/app -it --entrypoint /bin/bash ubuntu1604:php7

--- a/docker_run_php.sh
+++ b/docker_run_php.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+imagename='ubuntu1604:php7'
+filename="$1"
+docker build -t "${imagename}" .
+docker run -v $(pwd):/app -it --rm --name komodoscripts  \
+  "${imagename}" /bin/bash -c "php /app/${filename}"


### PR DESCRIPTION
Bunch of changes to `assetchains_walletsize.sh`
- removed whitespaces
- formatted the identation
- added ignorelist and ability to check walletsize for all KMD assetchains

Added `docker_run_php.sh`:
- The script will allow instantiation of a docker container which will have necessary php modules installed. It's much easier to run it irrespective of the OS you're running.